### PR TITLE
Revise the test scripts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: install-modern-asdf
       run:
-        mkdir /asdf && cd /asdf && wget -l https://asdf.common-lisp.dev/archives/asdf.lisp
+        mkdir /asdf && cd /asdf && wget https://asdf.common-lisp.dev/archives/asdf.lisp
 
     - name: SBCL
       if: ${{ matrix.lisp == 'sbcl' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,98 +17,40 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ${{matrix.os}}
 
+    container:
+      image: clfoundation/${{matrix.lisp}}:latest
+
     strategy:
       matrix:
         os: [ubuntu-latest]
         lisp:
-          - ccl
           - sbcl
-          - allegro
+          - ccl
+          # - allegro
+          # installation of quicklisp fails on Allegro for some reason. Have to fix this later.
+
+    env:
+      I_AGREE_TO_ALLEGRO_EXPRESS_LICENSE: yes
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    # - name: Checkout submodules
-    #   shell: bash
-    #   run: |
-    #     git submodule update --init --recursive
+    - run: install-quicklisp
 
-    # - name: cache validate
-    #   id: cache-validate
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: jenkins/VAL
-    #     key: ${{ runner.os }}
-
-    # - name: compile validate
-    #   if: steps.cache-validate.outputs.cache-hit != 'true'
-    #   shell: bash
-    #   run: |
-    #     cd jenkins/VAL
-    #     make
-
-    # - name: add validate to path
-    #   run: echo "${GITHUB_WORKSPACE}/jenkins/VAL" >> $GITHUB_PATH
-
-    # Lisp setup copied from here: https://github.com/3b/ci-example/blob/master/.github/workflows/CI.yml
-    - name: cache .roswell
-      id: cache-dot-roswell
-      uses: actions/cache@v1
-      with:
-        path: ~/.roswell
-        key: ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-${{ hashFiles('**/*.asd') }}
-        restore-keys: |
-          ${{ runner.os }}-dot-roswell-${{ matrix.lisp }}-
-          ${{ runner.os }}-dot-roswell-
-
-    - name: install roswell
-      shell: bash
-      # always run install, since it does some global installs and setup that isn't cached
-      env:
-       LISP: ${{ matrix.lisp }}
-      # Use a previous release of Roswell to avoid error encountered
-      # due to libcurl3 not being available.
-      # Source of fix: https://github.com/avodonosov/drakma/commit/fbba29181ba2962f5031da581bd2de4dac98733d
-      run: |
-        sudo apt-get install -y libcurl4
-        curl -L https://raw.githubusercontent.com/roswell/roswell/a8fd8a3c33078d6f06e6cda9d099dcba6fbefcb7/scripts/install-for-ci.sh | sh
-
-    - name: add dependencies to roswell
-      shell: bash
-      # always run install, since it does some global installs and setup that isn't cached
-      env:
-       LISP: ${{ matrix.lisp }}
-      # Use a previous release of Roswell to avoid error encountered
-      # due to libcurl3 not being available.
-      # Source of fix: https://github.com/avodonosov/drakma/commit/fbba29181ba2962f5031da581bd2de4dac98733d
-      run: |
-        ros install fiveam
-        ros install fiveam-asdf
-
-    # Compile first in a separate step to make the test output more readable
-    - name: compile lisp
-      shell: bash
-      run: |
-        ros -e "(cl:in-package :cl-user)
-           (prin1 (lisp-implementation-type)) (terpri) (prin1 (lisp-implementation-version)) (terpri)
-           (prin1 \"${{ matrix.test }}\") (terpri)
-           (asdf:initialize-source-registry  '(:source-registry (:tree \"$PWD/\") :inherit-configuration))
-           (declaim (optimize (speed 3)))
-           (asdf:load-system :pddl-utils/tests)
-           (uiop:quit 0)"
-
-    - name: tests
-      shell: bash
-      run: |
-        ros -e "(cl:in-package :cl-user)
-           (require :asdf)
-           (prin1 (lisp-implementation-type)) (terpri) (prin1 (lisp-implementation-version)) (terpri)
-           (prin1 \"${{ matrix.test }}\") (terpri)
-           (asdf:initialize-source-registry  '(:source-registry (:tree \"$PWD/\") :inherit-configuration))
-           (handler-case
-               (asdf:test-system :pddl-utils)
-            (error (e)
-               (format t \"~&Error in testing: ~a~%Backtrace:~%\" e)
-               (uiop:print-condition-backtrace e)
-               (uiop:quit 1)))
-           (uiop:quit 0)"
+    - name: SBCL
+      if: ${{ matrix.lisp == 'sbcl' }}
+      run: sbcl  --non-interactive
+        --load $GITHUB_WORKSPACE/do-test.lisp
+        --eval '(uiop:quit 0)'
+    - name: Allegro
+      if: ${{ matrix.lisp == 'allegro' }}
+      run: alisp -L /github/home/quicklisp/setup.lisp
+        -e "(asdf:load-asd \"$GITHUB_WORKSPACE/random-state.asd\")" 
+        -e '(ql:quickload "random-state/tests")'
+        -e '(asdf:test-system "random-state")'
+        --kill
+    - name: Clozure
+      if: ${{ matrix.lisp == 'ccl' }}
+      run: ccl --batch
+        --load $GITHUB_WORKSPACE/do-test.lisp
+        --eval '(uiop:quit 0)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest]
         lisp:
           - sbcl
-          # - ccl
+          - ccl
           # - allegro
           # installation of quicklisp fails on Allegro for some reason. Have to fix this later.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         lisp:
           - sbcl
           - ccl
-          # - allegro
+          - allegro
           # installation of quicklisp fails on Allegro for some reason. Have to fix this later.
 
     env:
@@ -47,13 +47,10 @@ jobs:
         --load /asdf/asdf.lisp
         --load $GITHUB_WORKSPACE/do-test.lisp
         --eval '(uiop:quit 0)'
-    # - name: Allegro
-    #   if: ${{ matrix.lisp == 'allegro' }}
-    #   run: alisp -L /github/home/quicklisp/setup.lisp
-    #     -e "(asdf:load-asd \"$GITHUB_WORKSPACE/random-state.asd\")" 
-    #     -e '(ql:quickload "random-state/tests")'
-    #     -e '(asdf:test-system "random-state")'
-    #     --kill
+    - name: Allegro
+      if: ${{ matrix.lisp == 'allegro' }}
+      run: alisp -L /asdf/asdf.lisp -L $GITHUB_WORKSPACE/do-test.lisp
+        --kill
     - name: Clozure
       if: ${{ matrix.lisp == 'ccl' }}
       run: ccl --batch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,20 +37,26 @@ jobs:
 
     - run: install-quicklisp
 
+    - name: install-modern-asdf
+      run:
+        mkdir /asdf && cd /asdf && wget -l https://asdf.common-lisp.dev/archives/asdf.lisp
+
     - name: SBCL
       if: ${{ matrix.lisp == 'sbcl' }}
       run: sbcl  --non-interactive
+        --load /asdf/asdf.lisp
         --load $GITHUB_WORKSPACE/do-test.lisp
         --eval '(uiop:quit 0)'
-    - name: Allegro
-      if: ${{ matrix.lisp == 'allegro' }}
-      run: alisp -L /github/home/quicklisp/setup.lisp
-        -e "(asdf:load-asd \"$GITHUB_WORKSPACE/random-state.asd\")" 
-        -e '(ql:quickload "random-state/tests")'
-        -e '(asdf:test-system "random-state")'
-        --kill
+    # - name: Allegro
+    #   if: ${{ matrix.lisp == 'allegro' }}
+    #   run: alisp -L /github/home/quicklisp/setup.lisp
+    #     -e "(asdf:load-asd \"$GITHUB_WORKSPACE/random-state.asd\")" 
+    #     -e '(ql:quickload "random-state/tests")'
+    #     -e '(asdf:test-system "random-state")'
+    #     --kill
     - name: Clozure
       if: ${{ matrix.lisp == 'ccl' }}
       run: ccl --batch
+        --load /asdf/asdf.lisp
         --load $GITHUB_WORKSPACE/do-test.lisp
         --eval '(uiop:quit 0)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest]
         lisp:
           - sbcl
-          - ccl
+          # - ccl
           # - allegro
           # installation of quicklisp fails on Allegro for some reason. Have to fix this later.
 

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -12,9 +12,7 @@
 
 (in-package :test)
 
-(let ((home-dir (uiop:getenv "HOME")))
-  (unless home-dir
-    (error "HOME environment variable not bound in container."))
+(let ((home-dir (user-homedir-pathname)))
   (let ((path (uiop:ensure-directory-pathname home-dir)))
     (load (merge-pathnames "setup.lisp" path))))
 

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -20,12 +20,13 @@
 
 (ql:quickload "fiveam-asdf")            ; without this, the ASDF defsystems don't load properly.
 
+#+nil
 (handler-case
     (assert (uiop:pathname-equal (uiop:pathname-directory-pathname (asdf:component-pathname (asdf:find-system "pddl-utils")))
-                              (uiop:pathname-directory-pathname *load-truename*)))
+                                 (uiop:pathname-directory-pathname *load-truename*)))
   (error () (uiop:die 2 "Not loading PDDL-tools from the expected location: ~A instead of expected ~a."
-                       (asdf:component-pathname (asdf:find-system "pddl-utils"))
-                       )))
+                      (asdf:component-pathname (asdf:find-system "pddl-utils"))
+                      )))
 
 ;;; check for clean build
 (defmacro build-system (name)

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -20,7 +20,8 @@
 (handler-case
  (assert (uiop:pathname-equal (asdf:component-pathname (asdf:find-system "pddl-utils"))
                               (uiop:pathname-directory-pathname *load-truename*)))
-  (error () (uiop:die 2 "Not loading RANDOM-STATE from the expected location.")))
+  (error () (uiop:die 2 "Not loading PDDL-tools from the expected location: ~A."
+                       (asdf:component-pathname (asdf:find-system "pddl-utils")))))
 
 ;;; check for clean build
 (defmacro build-system (name)

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -37,9 +37,10 @@
        (ql:quickload ,name :silent nil :verbose t))))
 
 (build-system "pddl-utils")
-;; (build-system "hddl-utils")
+(build-system "hddl-utils")
 
 (ql:quickload "pddl-utils/tests")
+(ql:quickload "hddl-utils/tests")
 
 (defmacro test-system (name)
   `(handler-case
@@ -48,6 +49,6 @@
        (uiop:quit 1))))
 
 (test-system "pddl-utils")
-;; (test-system "hddl-utils")
+(test-system "hddl-utils")
 
 (uiop:quit 0)

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -14,7 +14,7 @@
 
 (let ((home-dir (user-homedir-pathname)))
   (let ((path (uiop:ensure-directory-pathname home-dir)))
-    (load (merge-pathnames "setup.lisp" path))))
+    (load (merge-pathnames "quicklisp/setup.lisp" path))))
 
 (push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
 

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -42,7 +42,7 @@
 (defmacro test-system (name)
   `(handler-case
        (asdf:test-system ,name)
-     (asdf:fiveam-asdf-failure ()
+     (fiveam-asdf:fiveam-asdf-failure ()
        (uiop:quit 1))))
 
 (test-system "pddl-utils")

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -12,9 +12,6 @@
 
 (in-package :test)
 
-(load (merge-pathnames (make-pathname :directory '(:relative "quicklisp") :name "setup" :type "lisp")
-                       (user-homedir-pathname)))
-
 (push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
 
 (handler-case

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -37,10 +37,10 @@
        (ql:quickload ,name :silent nil :verbose t))))
 
 (build-system "pddl-utils")
-(build-system "hddl-utils")
+;; (build-system "hddl-utils")
 
 (ql:quickload "pddl-utils/tests")
-(ql:quickload "hddl-utils/tests")
+;;(ql:quickload "hddl-utils/tests")
 
 (defmacro test-system (name)
   `(handler-case
@@ -49,6 +49,6 @@
        (uiop:quit 1))))
 
 (test-system "pddl-utils")
-(test-system "hddl-utils")
+;; (test-system "hddl-utils")
 
 (uiop:quit 0)

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -12,7 +12,12 @@
 
 (in-package :test)
 
-(load "/root/quicklisp/setup.lisp")
+(let ((home-dir (uiop:getenv "HOME")))
+  (unless home-dir
+    (error "HOME environment variable not bound in container."))
+  (let ((path (uiop:ensure-directory-pathname home-dir)))
+    (load (merge-pathnames "setup.lisp")
+          path)))
 
 (push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
 

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -21,10 +21,11 @@
 (ql:quickload "fiveam-asdf")            ; without this, the ASDF defsystems don't load properly.
 
 (handler-case
- (assert (uiop:pathname-equal (asdf:component-pathname (asdf:find-system "pddl-utils"))
+    (assert (uiop:pathname-equal (uiop:pathname-directory-pathname (asdf:component-pathname (asdf:find-system "pddl-utils")))
                               (uiop:pathname-directory-pathname *load-truename*)))
-  (error () (uiop:die 2 "Not loading PDDL-tools from the expected location: ~A."
-                       (asdf:component-pathname (asdf:find-system "pddl-utils")))))
+  (error () (uiop:die 2 "Not loading PDDL-tools from the expected location: ~A instead of expected ~a."
+                       (asdf:component-pathname (asdf:find-system "pddl-utils"))
+                       )))
 
 ;;; check for clean build
 (defmacro build-system (name)

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -44,7 +44,7 @@
 (defmacro test-system (name)
   `(handler-case
        (asdf:test-system ,name)
-     (fiveam-asdf:fiveam-asdf-test-failure ()
+     (fiveam-asdf:fiveam-test-fail ()
        (uiop:quit 1))))
 
 (test-system "pddl-utils")

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -42,7 +42,7 @@
 (defmacro test-system (name)
   `(handler-case
        (asdf:test-system ,name)
-     (fiveam-asdf:fiveam-asdf-failure ()
+     (fiveam-asdf:fiveam-asdf-test-failure ()
        (uiop:quit 1))))
 
 (test-system "pddl-utils")

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -16,8 +16,7 @@
   (unless home-dir
     (error "HOME environment variable not bound in container."))
   (let ((path (uiop:ensure-directory-pathname home-dir)))
-    (load (merge-pathnames "setup.lisp")
-          path)))
+    (load (merge-pathnames "setup.lisp" path))))
 
 (push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
 

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -18,6 +18,8 @@
 
 (push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
 
+(ql:quickload "fiveam-asdf")            ; without this, the ASDF defsystems don't load properly.
+
 (handler-case
  (assert (uiop:pathname-equal (asdf:component-pathname (asdf:find-system "pddl-utils"))
                               (uiop:pathname-directory-pathname *load-truename*)))
@@ -31,8 +33,6 @@
      (let ((asdf:*compile-file-failure-behaviour* :error)
            (asdf:*compile-file-warnings-behaviour* :error))
        (ql:quickload ,name :silent nil :verbose t))))
-
-(ql:quickload "fiveam-asdf")            ; without this, the ASDF defsystems don't load properly.
 
 (build-system "pddl-utils")
 ;; (build-system "hddl-utils")

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -1,0 +1,45 @@
+#|
+ This file is a part of pddl-tools
+ (c) 2023 Robert P. Goldman and SIFT, LLC
+ Author: Robert P. Goldman <rpgoldman@sift.net>
+|#
+
+
+(in-package :common-lisp-user)
+
+(defpackage test
+  (:use :common-lisp))
+
+(in-package :test)
+
+(load (merge-pathnames (make-pathname :directory '(:relative "quicklisp") :name "setup" :type "lisp")
+                       (user-homedir-pathname)))
+
+(push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
+
+(handler-case
+ (assert (uiop:pathname-equal (asdf:component-pathname (asdf:find-system "pddl-utils"))
+                              (uiop:pathname-directory-pathname *load-truename*)))
+  (error () (uiop:die 2 "Not loading RANDOM-STATE from the expected location.")))
+
+;;; check for clean build
+(defmacro build-system (name)
+ `(handler-bind
+     ((error #'(lambda (c) (uiop:die 3 "Failed to build ~a cleanly with error:~%~T~a" ,name c))))
+   (let ((asdf:*compile-file-failure-behaviour* :error)
+         (asdf:*compile-file-warnings-behaviour* :error))
+     (ql:quickload ,name :silent nil :verbose t))))
+
+(build-system "pddl-utils")
+;; (build-system "hddl-utils")
+
+(defmacro test-system (name)
+  `(handler-case
+    (asdf:test-system ,name)
+  (asdf:fiveam-asdf-failure ()
+    (uiop:quit 1))))
+
+(test-system "pddl-utils")
+;; (test-system "hddl-utils")
+
+(uiop:quit 0)

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -12,6 +12,8 @@
 
 (in-package :test)
 
+(load "/root/quicklisp/setup.lisp")
+
 (push (namestring (uiop:pathname-directory-pathname *load-truename*)) ql:*local-project-directories*)
 
 (handler-case

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -26,20 +26,22 @@
 
 ;;; check for clean build
 (defmacro build-system (name)
- `(handler-bind
-     ((error #'(lambda (c) (uiop:die 3 "Failed to build ~a cleanly with error:~%~T~a" ,name c))))
-   (let ((asdf:*compile-file-failure-behaviour* :error)
-         (asdf:*compile-file-warnings-behaviour* :error))
-     (ql:quickload ,name :silent nil :verbose t))))
+  `(handler-bind
+       ((error #'(lambda (c) (uiop:die 3 "Failed to build ~a cleanly with error:~%~T~a" ,name c))))
+     (let ((asdf:*compile-file-failure-behaviour* :error)
+           (asdf:*compile-file-warnings-behaviour* :error))
+       (ql:quickload ,name :silent nil :verbose t))))
+
+(ql:quickload "fiveam-asdf")            ; without this, the ASDF defsystems don't load properly.
 
 (build-system "pddl-utils")
 ;; (build-system "hddl-utils")
 
 (defmacro test-system (name)
   `(handler-case
-    (asdf:test-system ,name)
-  (asdf:fiveam-asdf-failure ()
-    (uiop:quit 1))))
+       (asdf:test-system ,name)
+     (asdf:fiveam-asdf-failure ()
+       (uiop:quit 1))))
 
 (test-system "pddl-utils")
 ;; (test-system "hddl-utils")

--- a/do-test.lisp
+++ b/do-test.lisp
@@ -39,6 +39,8 @@
 (build-system "pddl-utils")
 ;; (build-system "hddl-utils")
 
+(ql:quickload "pddl-utils/tests")
+
 (defmacro test-system (name)
   `(handler-case
        (asdf:test-system ,name)

--- a/pddl/pddl-pprint.lisp
+++ b/pddl/pddl-pprint.lisp
@@ -18,23 +18,23 @@
 ;;; Interface functions
 ;;;---------------------------------------------------------------------------
 
-
-(defun pprint-pddl (sexp &optional (stream t) &key (canonical nil))
-  "Pretty-print a PDDL plan or domain.  Carefully crafted to
+(locally (declare #+sbcl (sb-ext:muffle-conditions style-warning))
+  (defun pprint-pddl (sexp &optional (stream t) &key (canonical nil))
+    "Pretty-print a PDDL plan or domain.  Carefully crafted to
 generate PDDL that the FF PDDL parser will read.
   If the CANONICAL keyword argument is T, then typed lists will be
 printed in \"canonical form\", as pairs like:
 FOO - TYPE1 BAR - TYPE1 BAZ - TYPE2
 instead of \"minimal form\" like
 FOO BAR - TYPE1 BAZ - TYPE2."
-  (let ((*print-pprint-dispatch* *pddl-pprint-dispatch*)
-        (*package* (find-package *pddl-package*))
-        (*canonical* canonical)
-        *is-problem* *is-domain*)
-    (cond ((domain-p sexp) (setf *is-domain* t))
-          ((problem-p sexp) (setf *is-problem* t))
-          (t (error "Can't determine if argument is problem or domain.")))
-    (pprint sexp stream)))
+    (let ((*print-pprint-dispatch* *pddl-pprint-dispatch*)
+          (*package* (find-package *pddl-package*))
+          (*canonical* canonical)
+          *is-problem* *is-domain*)
+      (cond ((domain-p sexp) (setf *is-domain* t))
+            ((problem-p sexp) (setf *is-problem* t))
+            (t (error "Can't determine if argument is problem or domain.")))
+      (pprint sexp stream))))
 
 (defun read-pddl-file (dom-prob-file)
   "Takes a domain or problem file and returns its s-expression."


### PR DESCRIPTION
Previously, we used `roswell`, but roswell is bit-rotted.