### PR TITLE
Cumbersome GitHub CI action rewrite to use bespoke Allegro image.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,22 +15,20 @@ on:
 jobs:
   test:
     # The type of runner that the job will run on
-    runs-on: ${{matrix.os}}
-
-    container:
-      image: clfoundation/${{matrix.lisp}}:latest
-
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        lisp:
-          - sbcl
-          - ccl
-          - allegro
-          # installation of quicklisp fails on Allegro for some reason. Have to fix this later.
+        ro: [ubuntu-latest]
+        lisp: [sbcl, ccl]
+          # installation of quicklisp fails on Allegro for some
+          # reason. Have to fix this later.
+
+    runs-on: ${{ matrix.ro }}
 
     env:
       I_AGREE_TO_ALLEGRO_EXPRESS_LICENSE: yes
+
+    container:
+      image: clfoundation/${{matrix.lisp}}:latest
 
     steps:
     - name: install JSON wrangling binaries
@@ -50,13 +48,42 @@ jobs:
         --load /asdf/asdf.lisp
         --load $GITHUB_WORKSPACE/do-test.lisp
         --eval '(uiop:quit 0)'
-    - name: Allegro
-      if: ${{ matrix.lisp == 'allegro' }}
-      run: alisp -L /asdf/asdf.lisp -L $GITHUB_WORKSPACE/do-test.lisp
-        --kill
     - name: Clozure
       if: ${{ matrix.lisp == 'ccl' }}
       run: ccl --batch
         --load /asdf/asdf.lisp
         --load $GITHUB_WORKSPACE/do-test.lisp
         --eval '(uiop:quit 0)'
+
+  test-allegro:
+    # The type of runner that the job will run on
+    strategy:
+      matrix:
+        ro: [ubuntu-latest]
+        lisp: [allegro]
+          # installation of quicklisp fails on Allegro for some
+          # reason. Have to fix this later.
+
+    runs-on: ${{ matrix.ro }}
+
+    env:
+      I_AGREE_TO_ALLEGRO_EXPRESS_LICENSE: yes
+
+    container:
+      image: rpgoldman/allegro11express:latest
+
+    steps:
+    - name: install JSON wrangling binaries
+      run: apt update && apt install -y jq python3 python3-pip && python3 -m pip install yq check-jsonschema
+
+    - uses: actions/checkout@v3
+
+    - run: install-quicklisp
+
+    - name: install-modern-asdf
+      run:
+        mkdir /asdf && cd /asdf && wget https://asdf.common-lisp.dev/archives/asdf.lisp
+
+    - name: Allegro
+      run: alisp -L /asdf/asdf.lisp -L $GITHUB_WORKSPACE/do-test.lisp
+        --kill

--- a/hddl/hddl-pprint.lisp
+++ b/hddl/hddl-pprint.lisp
@@ -124,7 +124,7 @@ in the form of a list of actions."
              (parse-integer line :junk-allowed t)
            (collecting
                (cons id
-                (ecase format
+                (case format
                   (:comma-separated
                    (comma-separated-task->sexp (subseq (string-upcase line) (1+ pos))))
                   (:s-expression
@@ -153,7 +153,7 @@ in the form of a list of actions."
                   (partition-method-line (subseq line (1+ pos)))
                 (declare (type string task-string method-id subtasks))
                 (collecting `(,id
-                              ,(ecase format
+                              ,(case format
                                  (:default
                                   (space-separated-string->hddl-list (string-upcase task-string)))
                                  (:s-expression


### PR DESCRIPTION
The `clfoundation` images seem to be bitrotting.